### PR TITLE
Move typescript and @types packages to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
       "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -208,8 +207,7 @@
     "@types/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
-      "dev": true
+      "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -1665,8 +1663,7 @@
     "typescript": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
-      "dev": true
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
   },
   "homepage": "https://github.com/rpiambulance/slack-poll#readme",
   "dependencies": {
+    "@types/dotenv": "^6.1.1",
+    "@types/express": "^4.17.1",
+    "@types/qs": "^6.5.3",
     "@slack/interactive-messages": "^1.3.0",
     "@slack/web-api": "^5.2.0",
     "body-parser": "^1.19.0",
     "dotenv": "^8.1.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "typescript": "^3.6.3"
   },
   "devDependencies": {
-    "@types/dotenv": "^6.1.1",
-    "@types/express": "^4.17.1",
-    "@types/qs": "^6.5.3",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
-    "eslint": "^6.5.1",
-    "typescript": "^3.6.3"
+    "eslint": "^6.5.1"
   }
 }


### PR DESCRIPTION
Typescript is a direct run-time requirement now as of #29 and so should be in `dependencies` given that `npm start` should be used by end-users (per @justetz on slack). 

I've also moved the `@types` packages to be in the same dependency block as the package they add types for.