### PR TITLE
Changed "Lock" to "Close" to reduce user confusion.

### DIFF
--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -48,8 +48,8 @@ export class Actions {
             case "bottom":
                 this.onBottomSelected(payload, poll);
                 break;
-            case "lock":
-                this.onLockSelected(payload, poll);
+            case "close":
+                this.onCloseSelected(payload, poll);
                 break;
             case "delete":
                 this.onDeleteSelected(payload, poll);
@@ -82,10 +82,10 @@ export class Actions {
 
     private onResetSelected(payload: any, poll: Poll): void {
         payload.message.text = "Vote reset!";
-        if (poll.getLockedStatus()) {
+        if (poll.getClosedStatus()) {
             this.wc.chat.postEphemeral({
                 channel: payload.channel.id,
-                text: "You cannot reset your vote after the poll has been locked.", user: payload.user.id
+                text: "You cannot reset your vote after the poll has been closed.", user: payload.user.id
             });
         } else {
             poll.resetVote(payload.user.id);
@@ -106,13 +106,13 @@ export class Actions {
         }
     }
 
-    private onLockSelected(payload: any, poll: Poll): void {
-        payload.message.text = "Poll locked!";
+    private onCloseSelected(payload: any, poll: Poll): void {
+        payload.message.text = "Poll is closed!";
         if (Actions.isPollAuthor(payload, poll)) {
-            poll.lockPoll();
+            poll.closePoll();
             payload.message.blocks = poll.getBlocks();
         } else {
-            this.postEphemeralOnlyAuthor("lock", "poll", payload.channel.id, payload.user.id);
+            this.postEphemeralOnlyAuthor("close", "poll", payload.channel.id, payload.user.id);
         }
     }
 

--- a/src/Poll.ts
+++ b/src/Poll.ts
@@ -57,7 +57,7 @@ export class Poll {
             placeholder: Static.buildTextElem("Poll Options"),
             options: [
                 Static.buildSelectOption("Reset your vote", "reset"),
-                Static.buildSelectOption(":lock: Lock poll", "lock"),
+                Static.buildSelectOption("Close the poll", "close"),
                 Static.buildSelectOption("Move to bottom", "bottom"),
                 Static.buildSelectOption("Delete poll", "delete")
             ]
@@ -77,14 +77,14 @@ export class Poll {
     private message: KnownBlock[] = [];
     private multiple = false;
     private anonymous = false;
-    private isLocked = false;
+    private isClosed = false;
     constructor(message: KnownBlock[]) {
         this.message = message;
         // Since its databaseless the way we know if it is anonymous or multiple is by parsing the title
         this.multiple = this.checkIfMsgContains("(Multiple Answers)");
         this.anonymous = this.checkIfMsgContains("(Anonymous)");
-        // If there's no buttons then the poll is locked
-        this.isLocked = this.message[3].type === "divider";
+        // If there's no buttons then the poll is closed
+        this.isClosed = this.message[3].type === "divider";
     }
 
     public getBlocks(): KnownBlock[] {
@@ -95,8 +95,8 @@ export class Poll {
         return ((this.message[1] as ContextBlock).elements[0] as PlainTextElement).text.replace("Asked by: ", "");
     }
 
-    public getLockedStatus(): boolean {
-        return this.isLocked;
+    public getClosedStatus(): boolean {
+        return this.isClosed;
     }
 
     private getVotesAndUserIndex(button: Button, userId: string): { votes: string[]; userIdIndex: number } {
@@ -130,9 +130,9 @@ export class Poll {
         this.generateVoteResults();
     }
 
-    public lockPoll(): void {
-        if (this.isLocked) return;
-        this.isLocked = true;
+    public closePoll(): void {
+        if (this.isClosed) return;
+        this.isClosed = true;
         this.generateVoteResults();
         this.message = this.message.slice(0, 2).concat(this.message.slice(this.getDividerId() - 1));
         // ((this.message[2] as ActionsBlock).elements[0] as StaticSelect).options!.splice(0, 2);
@@ -178,7 +178,7 @@ export class Poll {
             return false;
         });
         const sections = Object.keys(votes).map(key => this.buildVoteTally(overrideAnon, votes, key) as SectionBlock);
-        if (this.isLocked) sections.unshift(Static.buildSectionBlock(":lock:"));
+        if (this.isClosed) sections.unshift(Static.buildSectionBlock(":lock:"));
         return sections;
     }
 


### PR DESCRIPTION
Changed  "Lock" to "Close the" in the Options Menu.
Changed from "Lock" to "Close" for functions and variables to reduce confusion for future developers.
Kept the ":lock:" emoji to symbolize to the public that the poll is closed. 

Side Note: Took a poll of a random non technical group to find out whether "Close" or "End" would be a better word. Results can be found below:
![image](https://user-images.githubusercontent.com/21091716/67135601-66730a00-f1e9-11e9-9b86-70bc7a9a0eb4.png)
