### PR TITLE
Fixed greater than/less than replacement

### DIFF
--- a/src/Poll.ts
+++ b/src/Poll.ts
@@ -45,8 +45,8 @@ export class Poll {
                 actionBlockCount++;
             }
             // Remove special characters, should be able to remove this once slack figures itself out
-            parameters[i] = parameters[i].replace("&amp;", "+").replace("&lt;", "greater than ")
-                .replace("&gt;", "less than ");
+            parameters[i] = parameters[i].replace("&amp;", "+").replace("&gt;", "greater than ")
+                .replace("&lt;", "less than ");
             // We set value to empty string so that it is always defined
             const button: Button = { type: "button", value: " ", text: PollHelpers.buildTextElem(parameters[i]) };
             actionBlocks[actionBlockCount].elements.push(button);


### PR DESCRIPTION
Currently, it replaces < with greater than and > with less than.  This should be opposite.
Was fixed in #40 however that  PR will need some finagling anyways to be pulled, so this is a quicker solution. 